### PR TITLE
Use end date

### DIFF
--- a/src/core/statistics.js
+++ b/src/core/statistics.js
@@ -12,7 +12,7 @@ class Statistics {
             let sum = 0;
             
             if (this.options.endDate) {
-                if (date < this.options.endDate) {
+                if (date > this.options.endDate) {
                     return;
                 }
             }

--- a/src/core/statistics.js
+++ b/src/core/statistics.js
@@ -11,6 +11,12 @@ class Statistics {
         try {
             let sum = 0;
             
+            if (this.options.endDate) {
+                if (date < this.options.endDate) {
+                    return;
+                }
+            }
+
             if (this.lastStatistic) {
                 // Validate
                 if (this.validateDataOptions.includes(this.options.validateData)) {

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -49,7 +49,7 @@ group by sm.Id, sm.statistic_id, sm.unit_of_measurement
         </li>
         <li>
           Specify an end date to prevent overlapping data.<br/>
-          <input if="endDate" type="date"></input>
+          <input id="endDate" type="date"></input>
         </li>
         <li>
           What would you like to do with existing data?<br/>

--- a/src/ui/index.html
+++ b/src/ui/index.html
@@ -21,26 +21,6 @@ join statistics_meta sm on sm.id = s.metadata_id and has_sum = true
 group by sm.Id, sm.statistic_id, sm.unit_of_measurement
             </textarea>
           </li>
-          <li>
-            Update the number with the Id of the sensor you want to update.<br />
-            <input id="metadataId" type="number" value="1" />
-          </li>
-          <li>
-            Validate, skip or add erroneous data?<br/>
-            <select id="validateData">
-              <option value="validate">The import will stop on erroneous data</option>
-              <option value="skip">The import will skip erroneous data</option>
-              <option value="">No validation is done and every value will be added</option>
-            </select>
-          </li>
-          <li>
-            What would you like to do with existing data?<br/>
-            <select id="existingDataMode">
-              <option value="update">Update sum with total sum of history (sum is updated, can only be done once!)</option>
-              <option value="delete">Delete existing data</option>
-              <option value="">Do nothing with existing data (sum may become incorrect)</option>
-            </select>
-          </li>
         </ol>
       
       <h2>Create import scripts</h2>
@@ -53,6 +33,31 @@ group by sm.Id, sm.statistic_id, sm.unit_of_measurement
         <li>
           Select an entity to import. <br/>
           <select id="entityId">
+          </select>
+        </li>
+        <li>
+          Id of the sensor you want to update.<br />
+          <input id="metadataId" type="number" value="1" />
+        </li>
+        <li>
+          Validate, skip or add erroneous data?<br/>
+          <select id="validateData">
+            <option value="validate">The script will stop on erroneous data</option>
+            <option value="skip">The script will skip erroneous data</option>
+            <option value="">No validation is done and every value will be added</option>
+          </select>
+        </li>
+        <li>
+          Specify an end date to prevent overlapping data.<br/>
+          <input if="endDate" type="date"></input>
+        </li>
+        <li>
+          What would you like to do with existing data?<br/>
+          Home Assistant stores <i>relative</i> data. Any current data started at value 0.<br/>
+          <select id="existingDataMode">
+            <option value="update">Update existing relative with total sum of imported values (overwriting existing data can only be done once!)</option>
+            <option value="delete">Delete existing data</option>
+            <option value="">Do nothing with existing data (next day value may become incorrect)</option>
           </select>
         </li>
         <li>

--- a/src/ui/index.js
+++ b/src/ui/index.js
@@ -25,6 +25,7 @@ async function openFile(filePath = null) {
         existingDataMode: document.getElementById('existingDataMode').value,
         transformValueMode: document.getElementById('transformValueMode').value,
         validateData: document.getElementById('validateData').value,
+        endDate: document.getElementById('endDate').value,
     };
     const response = await window.electronAPI.createImport(filePath, metadata_id, entityId, options);
     console.log('openFile', response);


### PR DESCRIPTION
Maybe fixes #151.
- An end date can now be set. Helps preventing overlapping data.
- Altered the options page so options altering the script are together.
- Altered the 'existing data' option description. It no longer talks about 'sum' but what to do with the relative existing data. Hope that helps to make it more clear to users. 