### PR TITLE
Update GitVersion to 6.x

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
         id: gitversion
         uses: gittools/actions/gitversion/setup@main
         with:
-          versionSpec: '5.x'
+          versionSpec: '6.x'
 
       - name: Set up Python
         uses: actions/setup-python@v2


### PR DESCRIPTION
## Summary
- use the 6.x version of GitVersion in the release workflow

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6868b820e3d4832090f5ab3670925051