### PR TITLE
Fix GitVersion JSON error

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,13 +18,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Install GitVersion
         id: gitversion
-        uses: gittools/actions/gitversion/setup@main
+        uses: gittools/actions/gitversion/setup@v4
         with:
           versionSpec: '6.x'
 
@@ -34,7 +34,7 @@ jobs:
           python-version: '3.x'
 
       - name: Determine Version
-        uses: gittools/actions/gitversion/execute@main
+        uses: gittools/actions/gitversion/execute@v4
 
       - name: 'Set version number in package.json (MacOS)'
         if: runner.os == 'macOS'


### PR DESCRIPTION
## Summary
- pin GitVersion action to `v4` release

## Testing
- `npm --version`


------
https://chatgpt.com/codex/tasks/task_e_6868b9ba02988320a09b4abe34d58639